### PR TITLE
make smudge+clean idempotent on 0-length files

### DIFF
--- a/git-fat
+++ b/git-fat
@@ -266,7 +266,10 @@ class GitFat(object):
                     os.rename(tmpname, objfile)
                     self.verbose('git-fat filter-clean: caching to %s' % objfile)
                 cached = True
-                outstreamclean.write(self.encode(digest, bytes))
+                if bytes != 0:
+                    outstreamclean.write(self.encode(digest, bytes))
+                else:
+                    self.verbose('git-fat filter-clean: not modifying 0 length file')
         finally:
             if not cached:
                 os.remove(tmpname)


### PR DESCRIPTION
This is possibly a workaround for a git bug, git might not always run 
the clean filter on 0-length files, see https://github.com/jedbrown/git-fat/issues/18

Patch-author: @trenouf
